### PR TITLE
Fix for issue where spawning a npc would change relation of its default group with player

### DIFF
--- a/client/npcs.lua
+++ b/client/npcs.lua
@@ -39,8 +39,7 @@ function NearPed(npcmodel, npccoords, bankid)
     SetEntityInvincible(spawnedPed, true)
     FreezeEntityPosition(spawnedPed, true)
     SetBlockingOfNonTemporaryEvents(spawnedPed, true)
-    SetPedRelationshipGroupHash(spawnedPed, GetPedRelationshipGroupHash(spawnedPed))
-    SetRelationshipBetweenGroups(1, GetPedRelationshipGroupHash(spawnedPed), `PLAYER`)
+    SetPedCanBeTargetted(spawnedPed, false)
     if Config.FadeIn then
         for i = 0, 255, 51 do
             Wait(50)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 game 'rdr3'
 
 description 'rsg-banking'
-version '2.0.1'
+version '2.0.2'
 
 shared_scripts {
     '@ox_lib/init.lua',


### PR DESCRIPTION
Steps to reproduce issue
1) walk to bank npc and let it spawn
2) go outside and try to punch people (it would allow only pushing)

Instead of setting ped's default group friendly to player (assuming to prevent player from punching it), we can disable targeting of the ped and not change default ped group relation with player, which has unintended side effects, where we cannot freely attack ambient peds